### PR TITLE
[FEAT] 최근 채팅 히스토리 {human : ai} 5쌍 참고하여 단체방 캐릭터 중 어떤 캐릭터가 대답할지 FASTAPI 메소드 호출하여 캐릭터 리스트 반환

### DIFF
--- a/src/main/java/com/dlp/back/chatMessage/controller/ChatMessageController.java
+++ b/src/main/java/com/dlp/back/chatMessage/controller/ChatMessageController.java
@@ -1,11 +1,7 @@
 package com.dlp.back.chatMessage.controller;
 
-import com.dlp.back.chatMessage.domain.dto.ChatRequest;
-import com.dlp.back.chatMessage.domain.dto.MsgImgRequest;
-import com.dlp.back.chatMessage.domain.entity.ChatMessage;
+import com.dlp.back.chatMessage.domain.dto.*;
 import com.dlp.back.chatMessage.service.ChatMessageService;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +13,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Tag(name = "ChatMessage")
 @RestController
@@ -67,4 +62,41 @@ public class ChatMessageController {
                     .body(Collections.emptyList());
         }
     }
+
+    @PostMapping("/selectCharacterIdList")
+    public ResponseEntity<List<Long>> selectCharacterIdFastAPI(@RequestBody CharacterMatchRequest characterMatchRequest) {
+        // sessionId 이용해서 최근 5쌍의 채팅 히스토리 조회
+        Long sessionId = characterMatchRequest.getConversationId();
+        List<String> recentChatHistoryList = chatMessageService.getRecentChatHistoryList(sessionId);
+
+        CharacterMatchRequestFastAPI characterMatchRequestFastAPI = new CharacterMatchRequestFastAPI(
+                characterMatchRequest.getQuestion(),
+                characterMatchRequest.getCharIdList(),
+                recentChatHistoryList
+        );
+
+        try {
+            List<Long> selectedCharIdList = chatMessageService.selectCharacterIdFastAPI(characterMatchRequestFastAPI);
+
+            return ResponseEntity.ok(selectedCharIdList);
+        } catch (Exception e) {
+            List<Long> error = Collections.emptyList();
+            log.error("내부 서버 오류 발생", e);
+            return ResponseEntity.status(500).body(error);
+        }
+    }
+
+    // sessionId 이용해서 최근 5쌍의 채팅 히스토리 조회
+//    @GetMapping("/getRecentHistory/{sessionId}")
+//    public ResponseEntity<List<String>> getRecentChatHistoryList(@PathVariable Long sessionId) {
+//        try {
+//            List<String> selectedCharIdList = chatMessageService.getRecentChatHistoryList(sessionId);
+//
+//            return ResponseEntity.ok(selectedCharIdList);
+//        } catch (Exception e) {
+//            List<String> error = Collections.emptyList();
+//            log.error("내부 서버 오류 발생", e);
+//            return ResponseEntity.status(500).body(error);
+//        }
+//    }
 }

--- a/src/main/java/com/dlp/back/chatMessage/domain/dto/CharacterMatchRequest.java
+++ b/src/main/java/com/dlp/back/chatMessage/domain/dto/CharacterMatchRequest.java
@@ -11,12 +11,12 @@ import java.util.List;
 @Setter
 @ToString
 @Builder
-public class CharacterMatchRequestFastAPI {
+public class CharacterMatchRequest {
     private String question;
+
+    @JsonProperty("conversation_id")
+    private Long conversationId;
 
     @JsonProperty("char_id_list")
     private List<Long> charIdList;
-
-    @JsonProperty("chat_history_list")
-    private List<String> chatHistoryList;
 }

--- a/src/main/java/com/dlp/back/chatMessage/domain/dto/CharacterMatchResponseFastAPI.java
+++ b/src/main/java/com/dlp/back/chatMessage/domain/dto/CharacterMatchResponseFastAPI.java
@@ -1,0 +1,17 @@
+package com.dlp.back.chatMessage.domain.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+@Builder
+public class CharacterMatchResponseFastAPI {
+    @JsonProperty("selected_char_id_list")
+    private List<Long> selectedCharIdList;
+}

--- a/src/main/java/com/dlp/back/chatMessage/repository/ChatMessageRepository.java
+++ b/src/main/java/com/dlp/back/chatMessage/repository/ChatMessageRepository.java
@@ -38,4 +38,13 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             "WHERE c.chatRoom.sessionId = :sessionId " +
             "ORDER BY c.id ASC")
     List<Map<String, Object>> findChatHistoryBySessionId(@Param("sessionId") Long sessionId);
+
+    @Query("SELECT " +
+            "CASE WHEN c.participant.character.charNo IS NULL THEN 'user' ELSE 'ai' END AS role, " +
+            "c.message AS message " +
+            "FROM ChatMessage c " +
+            "LEFT JOIN c.participant.character pc " +
+            "WHERE c.chatRoom.sessionId = :sessionId " +
+            "ORDER BY c.id DESC")
+    List<Map<String, Object>> findChatMessagesBySessionIdOrderByIdDesc(@Param("sessionId") Long sessionId);
 }


### PR DESCRIPTION
- FASTAPI의 /character/match 메소드(who 모델)에 요청하여 대답할 캐릭터 아이디 리스트를 반환하는 백엔드 메소드 추가
- 백엔드에 최근 히스토리 5쌍 가져오는 메소드 추가하여 FAST API에 히스토리 같이 보내기