### PR TITLE
Feature/group chat/chat room and send message

### DIFF
--- a/src/main/java/com/dlp/back/chatRoom/controller/ChatRoomController.java
+++ b/src/main/java/com/dlp/back/chatRoom/controller/ChatRoomController.java
@@ -180,7 +180,17 @@ public class ChatRoomController {
     @PostMapping("/create/balanceChatRoom")
     public ResponseEntity<ResponseMessage> createChatRoom3(@RequestBody ChatRoomInfo chatRoomInfo){
 
-        ChatRoom chatRoom = chatRoomService.createChatRoom2(chatRoomInfo);
+        // 해당 유저와 특정 캐릭터 간의 채팅방이 존재하는지 체크
+        ChatRoom foundChatRoom = chatRoomService.checkBalanceChatRoom(chatRoomInfo);
+
+        ChatRoom chatRoom;
+
+        if (foundChatRoom != null) {
+            chatRoom = foundChatRoom;
+        } else {
+            // 존재하는 채팅방이 없으면 채팅방 생성해주기
+            chatRoom = chatRoomService.createChatRoom2(chatRoomInfo);
+        }
 
         // 1번 인덱스부터 마지막 인덱스까지의 캐릭터를 리스트로 변환
         List<Character> characters = chatRoom.getParticipant().stream()

--- a/src/main/java/com/dlp/back/chatRoom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/dlp/back/chatRoom/repository/ChatRoomRepository.java
@@ -17,4 +17,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             "GROUP BY cr " +
             "HAVING COUNT(p) = 2")
     List<ChatRoom> findChatRoomsByCharNoAndMemberNo(Long charNo, Long memberNo);
+
+    ChatRoom findChatRoomByRoomName(String charName);
 }

--- a/src/main/java/com/dlp/back/chatRoom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/dlp/back/chatRoom/repository/ChatRoomRepository.java
@@ -10,7 +10,11 @@ import java.util.List;
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-    @Query("SELECT cr FROM ChatRoom cr JOIN cr.participant p1 JOIN cr.participant p2 " +
-            "WHERE p1.member.memberNo = :memberNo AND p2.character.charNo = :charNo")
+    @Query("SELECT cr FROM ChatRoom cr " +
+            "JOIN cr.participant p " +
+            "WHERE (p.member.memberNo = :memberNo AND p.character IS NULL) " +
+            "AND (p.character.charNo = :charNo AND p.member IS NULL) " +
+            "GROUP BY cr " +
+            "HAVING COUNT(p) = 2")
     List<ChatRoom> findChatRoomsByCharNoAndMemberNo(Long charNo, Long memberNo);
 }

--- a/src/main/java/com/dlp/back/chatRoom/service/ChatRoomService.java
+++ b/src/main/java/com/dlp/back/chatRoom/service/ChatRoomService.java
@@ -81,6 +81,12 @@ public class ChatRoomService {
         return chatRooms;
     }
 
+    public ChatRoom checkBalanceChatRoom(ChatRoomInfo chatRoomInfo) {
+        ChatRoom chatRoom = chatRoomRepository.findChatRoomByRoomName(chatRoomInfo.getCharName());
+
+        return chatRoom;
+    }
+
     public ChatRoom createChatRoom2(ChatRoomInfo chatRoomInfo) {
 
         Member member = memberRepository.findById(chatRoomInfo.getMemberNo()).get();
@@ -187,6 +193,7 @@ public class ChatRoomService {
                 .distinct()
                 .collect(Collectors.toList());
     }
+
 
 
 }


### PR DESCRIPTION
[FIX]
- 캐릭터 1:1 채팅방 입장시 유저1 + 캐릭터1 총합 2명만 들어있는 채팅방이 있는지 조회하도록  findChatRoomsByCharNoAndMemberNo 함수의 JPQL쿼리문 수정.
- 밸런스 채팅방 입장시 방 이름이 동일하면 기존의 방을 반환하도록 설정